### PR TITLE
docs(dip-0011): sync Identity specification with platform implementation

### DIFF
--- a/dip-0011.md
+++ b/dip-0011.md
@@ -28,7 +28,9 @@
         1. [Identity Create Transition](#identity-create-transition)
         1. [Identity Update Transition](#identity-update-transition)
         1. [Identity Topup Transition](#identity-topup-transition)
-        1. [Identity Disable Transition](#identity-disable-transition)
+        1. [Identity Disable Transition](#identity-disable-transition) (Reserved)
+        1. [Identity Credit Withdrawal Transition](#identity-credit-withdrawal-transition)
+        1. [Identity Credit Transfer Transition](#identity-credit-transfer-transition)
     1. [JSON Schema](#json-schema)
 1. [Copyright](#copyright)
 
@@ -77,7 +79,9 @@ Identities pay for the network cost of their transitions and resulting state cha
 
 As more applications come into existence, keys that are only used for a specific application, a group of applications (e.g., from a single developer) or to support a specific use-case can be added to an Identity. This is done using an [Identity Update Transition](#identity-update-transition). Identities can use this state transition to create and disable keys. This will be covered in depth in the keys section of this document.
 
-If an Identity has become compromised, the only recourse for its owner is to deactivate it using an [Identity Disable Transition](#identity-disable-transition). The transition that deactivates an Identity can be signed using keys disabled within a defined period of time after the key in question was disabled. This is because an attacker that gains control of a compromised Identity could immediately change the Identity keys. The real owner would then be left with only disabled keys. These disabled keys can only deactivate the Identity and not sign any other state transitions on behalf of the Identity. More complex recovery mechanisms for Identities will be the subject of a future DIP.
+Identities can transfer credits to other Identities using the [Identity Credit Transfer Transition](#identity-credit-transfer-transition), or withdraw credits back to the Dash Core chain using the [Identity Credit Withdrawal Transition](#identity-credit-withdrawal-transition). Both of these transitions require a key with the Transfer purpose (purpose 3).
+
+> **Note:** The [Identity Disable Transition](#identity-disable-transition) is reserved for future implementation. Once available, it will allow Identity owners to permanently deactivate a compromised Identity. More complex recovery mechanisms for Identities will be the subject of a future DIP.
 
 ## Identity Credits
 
@@ -149,6 +153,16 @@ Sending a contact request in Dashpay.
    </td>
   </tr>
   <tr>
+   <td>Transfer
+   </td>
+   <td>Critical
+   </td>
+   <td>Signing credit transfer and withdrawal state transitions. Token claims and transfers.
+   </td>
+   <td>Loss of credits/tokens.
+   </td>
+  </tr>
+  <tr>
    <td>Encryption
    </td>
    <td>Medium
@@ -168,17 +182,37 @@ Sending a contact request in Dashpay.
    <td>Ability to decrypt private received messages. Loss of privacy.
    </td>
   </tr>
+  <tr>
+   <td>Voting
+   </td>
+   <td>High
+   </td>
+   <td>Casting votes in platform governance.
+   </td>
+   <td>Loss of voting power. Potential governance manipulation.
+   </td>
+  </tr>
+  <tr>
+   <td>Owner
+   </td>
+   <td>Critical
+   </td>
+   <td>Proving ownership of a masternode or evonode.
+   </td>
+   <td>Loss of node control and associated rewards.
+   </td>
+  </tr>
 </table>
 
-The master authentication key is the sole key that can sign Identity updates or disable the Identity.
+The master authentication key is the sole key that can sign Identity updates. Keys with the Transfer purpose are required for signing credit transfer and withdrawal state transitions.
 
 Clients should use different practices for allowing access to these keys. A key with a critical or master security level should always require a user to authenticate when signing a transition. A key with a high security level should be available as long as the user has authenticated at least once during a session, this can be at the beginning of the session. A key with a medium security level should not require user authentication but must require access to the device. Clients should make use of these different security levels to give an ideal experience to end users and only ask them to authenticate when appropriate.
 
-Identities must be created with at least one authentication key in each security level. Keys can only be disabled if another valid key is enabled in the same security level. This can happen atomically in the same state transition. Contracts can define for each document type the minimal security level required for signing. Only keys of a higher security level can be used. If no such field is present then all keys except the medium security level keys can be used. Contracts are encouraged to use the security level the most appropriate for each document type.
+Identities must be created with at least one authentication key. Keys can only be disabled if another valid key remains enabled. This can happen atomically in the same state transition. Contracts can define for each document type the minimal security level required for signing. Only keys of a higher security level can be used. If no such field is present then all keys except the medium security level keys can be used. Contracts are encouraged to use the security level most appropriate for each document type.
 
 ## Encryption Keys
 
-Encryption and decryption keys are not valid for document signing. A key's purpose can be both for encryption and decryption simultaneously. While Identities must be registered with at least one authentication key in each security level, this is not the case for encryption and decryption keys. However, it is required that an Identity be registered and maintain at least one encryption key at a high security level and one decryption at a medium security level. Contracts that use encrypted fields should identify for each of these fields the key exchange protocol used, the hash function used in the key exchange and the encryption mechanism. Key exchange protocols could be such as elliptic curve Diffie-Hellman (ECDH) and if no key exchange protocol is set ECDH should be used as the default.
+Encryption and decryption keys are not valid for document signing. Identities can register separate encryption (purpose 1) and decryption (purpose 2) keys. Contracts that use encrypted fields should identify for each of these fields the key exchange protocol used, the hash function used in the key exchange and the encryption mechanism. Key exchange protocols could be such as elliptic curve Diffie-Hellman (ECDH) and if no key exchange protocol is set ECDH should be used as the default.
 
 When encrypting a field that is intended to be decrypted by a recipient, the owner of the document should use the private key of one of his encryption keys and a public decryption key valid on the recipient's Identity for the key exchange. On the recipient's side, the private key of the referenced decryption key and the referenced sender's encryption public key must be used.
 
@@ -198,7 +232,7 @@ Encryption and decryption keys are not guaranteed to be unique in Dash Platform.
 
 # Specification
 
-This section defines the Identity data model, the steps for signing transitions and the four Identity state transitions. Complementing this are validation rules and execution logic that together represent version 1 of the Identity protocol which is a part of Dash Platform Protocol.
+This section defines the Identity data model, the steps for signing transitions and the Identity state transitions. Complementing this are validation rules and execution logic that together represent the Identity protocol which is a part of Dash Platform Protocol.
 
 There are different ways to represent data depending on specific use cases. Thus all definitions of data structures are described independent of any particular representations. Structures defined below are maps of properties which are name-value pairs. Abstract data types are used to describe property values. The details on how structures and data types are implemented are described in the representations section below.
 
@@ -236,8 +270,8 @@ A list of public keys associated with the Identity.
 * Must be a list
 * Must contain [Identity Public Keys](#identity-public-key)
 * Must contain only unique items
-* Must have minimum length of 5
-* Must have maximum length of 4096
+* Must have minimum length of 1
+* Must have maximum length of 15000
 
 **_balance_**
 
@@ -254,13 +288,6 @@ Identity update revision is used for optimistic concurrency control. Incremented
 * Required
 * Must be an integer
 * Must be greater than or equal to 0
-
-**_isEnabled_**
-
-A boolean flag that indicates if the Identity is enabled or disabled. A disabled Identity cannot be updated, used for state transition signing or any other operations.
-
-* Required
-* Must be a boolean
 
 ### Identity Public Key
 
@@ -284,8 +311,11 @@ Public key type.
 * Required
 * Must be an integer
 * Possible values
-  * 0 - EC Secp256k1
+  * 0 - ECDSA Secp256k1
   * 1 - BLS 12-381
+  * 2 - ECDSA Hash160
+  * 3 - BIP13 Script Hash
+  * 4 - EDDSA 25519 Hash160
 
 **_purpose_**
 
@@ -297,7 +327,10 @@ Public key purpose.
   * 0 - Authentication
   * 1 - Encryption
   * 2 - Decryption
-  * 3 - Encryption and Decryption
+  * 3 - Transfer (used to sign credit transfer and withdrawal state transitions)
+  * 4 - System
+  * 5 - Voting
+  * 6 - Owner (used to prove ownership of a masternode or evonode)
 
 **_level_**
 
@@ -313,25 +346,33 @@ Public key associated security level.
 
 **_data_**
 
-Raw public key.
+Raw public key or key hash.
 
-_Note: For authentication using a public key hash can provide security benefits if the key is a single-use key, like in payment addresses, but provides no benefit when a key is used multiple times over its lifespan. Since the keys associated with an Identity are intended to be used repeatedly over an extended period of time, a raw public key is used instead of a public key hash._
+_Note: For authentication using a public key hash can provide security benefits if the key is a single-use key, like in payment addresses, but provides no benefit when a key is used multiple times over its lifespan. Since the keys associated with an Identity are intended to be used repeatedly over an extended period of time, a raw public key is used instead of a public key hash for key types 0 and 1. Key types 2-4 use hash representations for compatibility with Core chain addresses._
 
 * Required
 * Must be a byte array
 * Must have a length of
-  * 33 bytes for key type 0 (compressed format for EC Secp256k1 key)
+  * 33 bytes for key type 0 (compressed format for ECDSA Secp256k1 key)
   * 48 bytes for key type 1 (BLS 12-381)
+  * 20 bytes for key type 2 (ECDSA Hash160)
+  * 20 bytes for key type 3 (BIP13 Script Hash)
+  * 20 bytes for key type 4 (EDDSA 25519 Hash160)
 
-**_ownershipProof_**
+**_readOnly (optional)_**
 
-The proof of ownership for this key. This proof of ownership must sign the owner's Identity unique id.
+A boolean flag indicating whether this key is read-only. Read-only keys cannot be disabled or modified after creation.
 
-* Required
-* Must be a byte array
-* Must have a length of
-  * 65 bytes for key type 0 (compressed format for EC Secp256k1 key)
-  * 96 bytes for key type 1 (BLS 12-381)
+* Must be a boolean
+* Defaults to false if not specified
+
+**_contractBounds (optional)_**
+
+Optional bounds that restrict this key to specific contract usage. When set, the key can only be used for operations within the specified contract scope.
+
+* Must be an object with one of the following structures:
+  * Type 0 - SingleContract: `{ "type": 0, "id": "<contract-identifier>" }`
+  * Type 1 - SingleContractDocumentType: `{ "type": 1, "id": "<contract-identifier>", "documentTypeName": "<document-type-name>" }`
 
 **_disabledAt (optional)_**
 
@@ -476,12 +517,6 @@ This state transition creates an Identity as defined in the [Data Model section]
    <td>0
    </td>
   </tr>
-  <tr>
-   <td>isEnabled
-   </td>
-   <td>true
-   </td>
-  </tr>
 </table>
 
 ### Identity Update Transition
@@ -499,11 +534,11 @@ Identity protocol version.
 
 **_type_**
 
-Type of state transition. Identity Update Transition is type 4.
+Type of state transition. Identity Update Transition is type 5.
 
 * Required
 * Must be an integer
-* Must have value of 4
+* Must have value of 5
 
 **_identityId_**
 
@@ -520,6 +555,14 @@ Identity Update revision number.
 * Must be an integer
 * Must be incremented by one with each update to the Identity
 
+**_nonce_**
+
+A unique value to prevent replay attacks and ensure state transition uniqueness.
+
+* Required
+* Must be an integer
+* Must be greater than or equal to 0
+
 **_addPublicKeys (optional)_**
 
 Public key(s) to add to the Identity.
@@ -528,7 +571,7 @@ Public key(s) to add to the Identity.
 * Must contain [Identity Public Keys](#identity-public-key)
 * Must contain unique items
 * Must have minimum length of 1
-* Must have maximum length of N (N = 4096 - current keys count)
+* Must have maximum length of N (N = 15000 - current keys count)
 
 **_disablePublicKeys (optional)_**
 
@@ -541,16 +584,14 @@ Identity Public key ID(s) to disable for the Identity.
   * Must exist and be enabled in the Identity being updated
 * Must contain unique items
 * Must have a minimum length of 1
-* Must have a maximum length of 4096
+* Must have a maximum length of 15000
 
-**_publicKeysDisabledAt (optional)_**
+**_userFeeIncrease (optional)_**
 
-Timestamp when keys were disabled.
+Optional fee increase multiplier to prioritize the state transition.
 
 * Must be an integer
 * Must be greater than or equal to 0
-* Required if and only if `disablePublicKeys` is present
-* Must not be more than 5 minutes before or 5 minutes after the current platform chain block time at the moment of disabling
 
 **_signature_**
 
@@ -607,7 +648,7 @@ Disable the keys specified in disablePublicKeys:
 
 <li>data - Remains unchanged
 
-<li>disabledAt - Set to the state transition's publicKeysDisabledAt value
+<li>disabledAt - Set to the current platform chain block time
 </li>
 </ul>
    </td>
@@ -622,12 +663,6 @@ Disable the keys specified in disablePublicKeys:
    <td>revision
    </td>
    <td>revision from the state transition
-   </td>
-  </tr>
-  <tr>
-   <td>isEnabled
-   </td>
-   <td>Remains unchanged
    </td>
   </tr>
 </table>
@@ -723,17 +758,21 @@ This state transition increases the specified Identity's (`identityId`) balance.
    <td>Increased by one
    </td>
   </tr>
-  <tr>
-   <td>isEnabled
-   </td>
-   <td>Remains unchanged
-   </td>
-  </tr>
 </table>
 
 ### Identity Disable Transition
 
-The Identity Disable Transition allows an Identity owner to permanently deactivate their Identity. Data previously signed by a disabled Identity can still be verified, but any new state transitions signed by the Identity will be considered invalid. This state transition must be signed by one of their currently enabled keys or a key disabled within the last ninety days. The age of disabled keys is calculated by comparing the key's disable timestamp with the current time. This latter consideration is to prevent account hijacking attacks. For example, if an attacker obtains an Identity owner's private key and disables the owner's public key via the Identity Update Transition, the legitimate user can still disable the Identity with their old key. This can be used to remove the attacker's ability to access the Identity and associated data.
+> **Note: Reserved for Future Implementation**
+>
+> The Identity Disable Transition is not currently implemented in Dash Platform. This section is reserved for future development. A new state transition type number will be assigned when this feature is implemented, as type 5 is currently used by the Identity Update Transition.
+
+The Identity Disable Transition would allow an Identity owner to permanently deactivate their Identity. Data previously signed by a disabled Identity could still be verified, but any new state transitions signed by the Identity would be considered invalid. This state transition would need to be signed by one of the Identity's currently enabled keys or a key disabled within a defined recovery period. This consideration would prevent account hijacking attacks. For example, if an attacker obtains an Identity owner's private key and disables the owner's public key via the Identity Update Transition, the legitimate user could still disable the Identity with their old key. This could be used to remove the attacker's ability to access the Identity and associated data.
+
+_Detailed properties and execution logic will be defined when this feature is implemented._
+
+### Identity Credit Withdrawal Transition
+
+The Identity Credit Withdrawal Transition allows users to withdraw Platform Credits back to the Dash Core chain. This converts Platform Credits into Dash that can be sent to a specified Core chain address.
 
 #### Properties
 
@@ -746,19 +785,70 @@ Identity protocol version.
 
 **_type_**
 
-Type of state transitions. Identity Disable Transition is type 5.
+Type of state transition. Identity Credit Withdrawal Transition is type 6.
 
 * Required
 * Must be an integer
-* Must have a value of 5
+* Must have a value of 6
 
 **_identityId_**
 
-Unique identifier of the Identity to be disabled.
+Unique identifier of the Identity withdrawing credits.
 
+* Required
 * Must be a byte array
 * Must have a length of 32 bytes
-* The Identity with the specified ID must exist and be enabled
+* An Identity with the specified ID must exist
+
+**_amount_**
+
+Amount of credits to withdraw.
+
+* Required
+* Must be an integer
+* Must be greater than or equal to 1000 (minimum withdrawal amount)
+
+**_coreFeePerByte_**
+
+Fee per byte for the Core chain withdrawal transaction.
+
+* Required
+* Must be an integer
+* Must be between 1 and 4294967295
+
+**_pooling_**
+
+Withdrawal pooling option.
+
+* Required
+* Must be an integer
+* Possible values:
+  * 0 - Standard
+  * 1 - Never
+  * 2 - If Available
+
+**_outputScript_**
+
+Core chain output script specifying the destination address.
+
+* Required
+* Must be a byte array
+* Must have a length between 23 and 25 bytes
+
+**_nonce_**
+
+A unique value to prevent replay attacks and ensure state transition uniqueness.
+
+* Required
+* Must be an integer
+* Must be greater than or equal to 0
+
+**_userFeeIncrease (optional)_**
+
+Optional fee increase multiplier to prioritize the state transition.
+
+* Must be an integer
+* Must be greater than or equal to 0
 
 **_signature_**
 
@@ -777,10 +867,11 @@ The ID of public key used to sign the state transition.
 * Must be an integer
 * Must be greater than or equal to 0
 * Must exist in the specified Identity (`identityId`)
+* Must be a key with TRANSFER purpose (purpose 3)
 
 #### Execution
 
-The state transition disables the specified Identity (`identityId`). Values for the Identity's properties are updated as described in the table below:
+This state transition withdraws credits from the specified Identity (`identityId`). Values for the Identity's properties are updated as described in the table below:
 
 <table>
   <tr>
@@ -810,7 +901,7 @@ The state transition disables the specified Identity (`identityId`). Values for 
   <tr>
    <td>balance
    </td>
-   <td>Remains unchanged
+   <td>The current balance minus the withdrawal amount and fees for the state transition
    </td>
   </tr>
   <tr>
@@ -819,10 +910,171 @@ The state transition disables the specified Identity (`identityId`). Values for 
    <td>Increased by one
    </td>
   </tr>
+</table>
+
+### Identity Credit Transfer Transition
+
+The Identity Credit Transfer Transition allows users to transfer Platform Credits from one Identity to another Identity on Dash Platform.
+
+#### Properties
+
+**_protocolVersion_**
+
+Identity protocol version.
+
+* Must be an integer
+* Must be set to the current valid Identity protocol version
+
+**_type_**
+
+Type of state transition. Identity Credit Transfer Transition is type 7.
+
+* Required
+* Must be an integer
+* Must have a value of 7
+
+**_identityId_**
+
+Unique identifier of the Identity sending credits.
+
+* Required
+* Must be a byte array
+* Must have a length of 32 bytes
+* An Identity with the specified ID must exist
+
+**_recipientId_**
+
+Unique identifier of the Identity receiving credits.
+
+* Required
+* Must be a byte array
+* Must have a length of 32 bytes
+* An Identity with the specified ID must exist
+
+**_amount_**
+
+Amount of credits to transfer.
+
+* Required
+* Must be an integer
+* Must be greater than or equal to 1000 (minimum transfer amount)
+
+**_nonce_**
+
+A unique value to prevent replay attacks and ensure state transition uniqueness.
+
+* Required
+* Must be an integer
+* Must be greater than or equal to 0
+
+**_userFeeIncrease (optional)_**
+
+Optional fee increase multiplier to prioritize the state transition.
+
+* Must be an integer
+* Must be greater than or equal to 0
+
+**_signature_**
+
+Cryptographic signature of the state transition.
+
+* Required
+* Must be a byte array
+* Must have a length of 65 bytes
+* Must be created by the key specified in `signaturePublicKeyId`
+
+**_signaturePublicKeyId_**
+
+The ID of public key used to sign the state transition.
+
+* Required
+* Must be an integer
+* Must be greater than or equal to 0
+* Must exist in the specified Identity (`identityId`)
+* Must be a key with TRANSFER purpose (purpose 3)
+
+#### Execution
+
+This state transition transfers credits from the sender Identity (`identityId`) to the recipient Identity (`recipientId`). Values for both Identities' properties are updated as described in the table below:
+
+**Sender Identity:**
+
+<table>
   <tr>
-   <td>isEnabled
+   <td><strong>Property name</strong>
    </td>
-   <td>false
+   <td><strong>Property value</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>protocolVersion
+   </td>
+   <td>Remains unchanged
+   </td>
+  </tr>
+  <tr>
+   <td>id
+   </td>
+   <td>Remains unchanged
+   </td>
+  </tr>
+  <tr>
+   <td>publicKeys
+   </td>
+   <td>Remains unchanged
+   </td>
+  </tr>
+  <tr>
+   <td>balance
+   </td>
+   <td>The current balance minus the transfer amount and fees for the state transition
+   </td>
+  </tr>
+  <tr>
+   <td>revision
+   </td>
+   <td>Increased by one
+   </td>
+  </tr>
+</table>
+
+**Recipient Identity:**
+
+<table>
+  <tr>
+   <td><strong>Property name</strong>
+   </td>
+   <td><strong>Property value</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>protocolVersion
+   </td>
+   <td>Remains unchanged
+   </td>
+  </tr>
+  <tr>
+   <td>id
+   </td>
+   <td>Remains unchanged
+   </td>
+  </tr>
+  <tr>
+   <td>publicKeys
+   </td>
+   <td>Remains unchanged
+   </td>
+  </tr>
+  <tr>
+   <td>balance
+   </td>
+   <td>The current balance plus the transfer amount
+   </td>
+  </tr>
+  <tr>
+   <td>revision
+   </td>
+   <td>Remains unchanged
    </td>
   </tr>
 </table>
@@ -836,7 +1088,9 @@ Dash Platform Protocol implementations use [JSON Schema Draft 7](https://json-sc
 * [identityCreateTransition.json](dip-0011/identityCreateTransition.json)
 * [identityUpdateTransition.json](dip-0011/identityUpdateTransition.json)
 * [identityTopUpTransition.json](dip-0011/identityTopUpTransition.json)
-* [identityDisableTransition.json](dip-0011/identityDisableTransition.json)
+* [identityDisableTransition.json](dip-0011/identityDisableTransition.json) (reserved for future implementation)
+* [identityCreditWithdrawalTransition.json](dip-0011/identityCreditWithdrawalTransition.json)
+* [identityCreditTransferTransition.json](dip-0011/identityCreditTransferTransition.json)
 
 # Copyright
 

--- a/dip-0011/identity.json
+++ b/dip-0011/identity.json
@@ -18,10 +18,10 @@
         },
         "publicKeys": {
             "type": "array",
-            "minItems": 5,
-            "maxItems": 255,
+            "minItems": 1,
+            "maxItems": 15000,
             "uniqueItems": true,
-            "items": IdentityPublicKey,
+            "items": "IdentityPublicKey"
         },
         "balance": {
             "type": "integer",
@@ -33,17 +33,12 @@
             "minimum": 0,
             "description": "Identity update revision",
             "$comment": "Incremented by one with each new update so that the update will fail if the underlying data is modified between reading and writing"
-        },
-        "isEnabled": {
-            "type": "boolean",
-            "$comment": "A disabled identity can't be updated, used for State Transition signing or any other operations"
-        },
+        }
     },
     "required": [
         "id",
         "publicKeys",
         "balance",
-        "revision",
-        "isEnabled"
+        "revision"
     ]
 }

--- a/dip-0011/identityCreditTransferTransition.json
+++ b/dip-0011/identityCreditTransferTransition.json
@@ -8,9 +8,9 @@
             "$comment": "Maximum equals the latest Identity protocol version"
         },
         "type": {
-            "const": 5,
+            "const": 7,
             "description": "State transition type",
-            "$comment": "Identity Update Transition is type 5"
+            "$comment": "Identity Credit Transfer Transition is type 7"
         },
         "identityId": {
             "type": "string",
@@ -18,40 +18,27 @@
             "minLength": 42,
             "maxLength": 44,
             "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$",
-            "description": "Identity ID that should be updated.",
-            "$comment": "Identity with the specified ID must exist and contain the key that was used to sign the state transition"
+            "description": "Identity ID sending credits",
+            "$comment": "Identity with the specified ID must exist"
         },
-        "revision": {
+        "recipientId": {
+            "type": "string",
+            "contentEncoding": "base58",
+            "minLength": 42,
+            "maxLength": 44,
+            "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$",
+            "description": "Identity ID receiving credits",
+            "$comment": "Identity with the specified ID must exist"
+        },
+        "amount": {
             "type": "integer",
-            "minimum": 0,
-            "description": "Identity update revision",
-            "$comment": "Must be incremented by one with each update"
+            "minimum": 1000,
+            "description": "Amount of credits to transfer"
         },
         "nonce": {
             "type": "integer",
             "minimum": 0,
             "description": "Unique value to prevent replay attacks"
-        },
-        "addPublicKeys": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 15000,
-            "uniqueItems": true,
-            "items": "IdentityPublicKeyInCreation",
-            "description": "Public keys to add",
-            "$comment": "The overall number of identity public keys must not be greater than 15000"
-        },
-        "disablePublicKeys": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 15000,
-            "uniqueItems": true,
-            "items": {
-                "type": "integer",
-                "minimum": 0,
-                "description": "Identity public key ID",
-                "$comment": "Provided key(s) must exist and be enabled"
-            }
         },
         "userFeeIncrease": {
             "type": "integer",
@@ -61,7 +48,8 @@
         "signaturePublicKeyId": {
             "type": "integer",
             "minimum": 0,
-            "description": "The ID of public key used to sign the state transition"
+            "description": "The ID of public key used to sign the state transition",
+            "$comment": "Must be a key with TRANSFER purpose (purpose 3)"
         },
         "signature": {
             "type": "string",
@@ -71,19 +59,12 @@
             "description": "Cryptographic signature of the state transition"
         }
     },
-    "anyOf": [
-        {
-            "required": ["addPublicKeys"]
-        },
-        {
-            "required": ["disablePublicKeys"]
-        }
-    ],
     "required": [
         "protocolVersion",
         "type",
         "identityId",
-        "revision",
+        "recipientId",
+        "amount",
         "nonce",
         "signaturePublicKeyId",
         "signature"

--- a/dip-0011/identityCreditWithdrawalTransition.json
+++ b/dip-0011/identityCreditWithdrawalTransition.json
@@ -8,9 +8,9 @@
             "$comment": "Maximum equals the latest Identity protocol version"
         },
         "type": {
-            "const": 5,
+            "const": 6,
             "description": "State transition type",
-            "$comment": "Identity Update Transition is type 5"
+            "$comment": "Identity Credit Withdrawal Transition is type 6"
         },
         "identityId": {
             "type": "string",
@@ -18,40 +18,37 @@
             "minLength": 42,
             "maxLength": 44,
             "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$",
-            "description": "Identity ID that should be updated.",
-            "$comment": "Identity with the specified ID must exist and contain the key that was used to sign the state transition"
+            "description": "Identity ID withdrawing credits",
+            "$comment": "Identity with the specified ID must exist"
         },
-        "revision": {
+        "amount": {
             "type": "integer",
-            "minimum": 0,
-            "description": "Identity update revision",
-            "$comment": "Must be incremented by one with each update"
+            "minimum": 1000,
+            "description": "Amount of credits to withdraw"
+        },
+        "coreFeePerByte": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 4294967295,
+            "description": "Fee per byte for the Core chain withdrawal transaction"
+        },
+        "pooling": {
+            "type": "integer",
+            "enum": [0, 1, 2],
+            "description": "Withdrawal pooling option. 0 - Standard, 1 - Never, 2 - If Available"
+        },
+        "outputScript": {
+            "type": "string",
+            "contentEncoding": "base64",
+            "minLength": 31,
+            "maxLength": 34,
+            "description": "Core chain output script specifying the destination address",
+            "$comment": "23-25 bytes base64 encoded"
         },
         "nonce": {
             "type": "integer",
             "minimum": 0,
             "description": "Unique value to prevent replay attacks"
-        },
-        "addPublicKeys": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 15000,
-            "uniqueItems": true,
-            "items": "IdentityPublicKeyInCreation",
-            "description": "Public keys to add",
-            "$comment": "The overall number of identity public keys must not be greater than 15000"
-        },
-        "disablePublicKeys": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 15000,
-            "uniqueItems": true,
-            "items": {
-                "type": "integer",
-                "minimum": 0,
-                "description": "Identity public key ID",
-                "$comment": "Provided key(s) must exist and be enabled"
-            }
         },
         "userFeeIncrease": {
             "type": "integer",
@@ -61,7 +58,8 @@
         "signaturePublicKeyId": {
             "type": "integer",
             "minimum": 0,
-            "description": "The ID of public key used to sign the state transition"
+            "description": "The ID of public key used to sign the state transition",
+            "$comment": "Must be a key with TRANSFER purpose (purpose 3)"
         },
         "signature": {
             "type": "string",
@@ -71,19 +69,14 @@
             "description": "Cryptographic signature of the state transition"
         }
     },
-    "anyOf": [
-        {
-            "required": ["addPublicKeys"]
-        },
-        {
-            "required": ["disablePublicKeys"]
-        }
-    ],
     "required": [
         "protocolVersion",
         "type",
         "identityId",
-        "revision",
+        "amount",
+        "coreFeePerByte",
+        "pooling",
+        "outputScript",
         "nonce",
         "signaturePublicKeyId",
         "signature"

--- a/dip-0011/identityDisableTransition.json
+++ b/dip-0011/identityDisableTransition.json
@@ -1,25 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "properties": {
-        "protocolVersion": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 0,
-            "$comment": "Maximum equals the latest Identity protocol version"
-        },
-        "identityId": {
-            "type": "string",
-            "contentEncoding": "base58",
-            "minLength": 42,
-            "maxLength": 44,
-            "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$",
-            "description": "Identity ID that should be disabled",
-            "$comment": "Identity with specified ID must exist, be enabled and contain the key that was used to sign the state transition"
-        },
-    },
-    "$comment": "The key used to sign the state transition must either be currently enabled or disabled no longer than 90 days ago",
-    "required": [
-        "protocolVersion",
-        "identityId"
-    ]
+    "$comment": "RESERVED FOR FUTURE IMPLEMENTATION - The Identity Disable Transition is not currently implemented in Dash Platform. This schema is a placeholder and will be updated when the feature is implemented. Note: Type 5 is now used by Identity Update Transition, so a new type number will be assigned.",
+    "description": "Reserved - Identity Disable Transition (not yet implemented)",
+    "properties": {},
+    "required": []
 }

--- a/dip-0011/identityPublicKey.json
+++ b/dip-0011/identityPublicKey.json
@@ -6,100 +6,109 @@
             "type": "integer",
             "minimum": 0,
             "description": "Public key ID",
-            "$comment": "Must be unique for the identity. It can’t be changed after adding a key. Included when signing state transitions to indicate which identity key was used to sign."
+            "$comment": "Must be unique for the identity. It can't be changed after adding a key. Included when signing state transitions to indicate which identity key was used to sign."
         },
         "type": {
             "type": "integer",
-            "enum": [
-                0,
-                1
-            ],
-            "description": "Public key type. 0 - EC Secp256k1, 1 - BLS 12-381",
-            "$comment": "It can’t be changed after adding a key"
+            "enum": [0, 1, 2, 3, 4],
+            "description": "Public key type. 0 - ECDSA Secp256k1, 1 - BLS 12-381, 2 - ECDSA Hash160, 3 - BIP13 Script Hash, 4 - EDDSA 25519 Hash160",
+            "$comment": "It can't be changed after adding a key"
         },
         "purpose": {
             "type": "integer",
-            "enum": [
-                0,
-                1,
-                2,
-                3
-            ],
-            "description": "Public key purpose. 0 - Authentication, 1 - Encryption, 2 - Decryption, 3 - Encryption and Decryption",
-            "$comment": "It can’t be changed after adding a key"
+            "enum": [0, 1, 2, 3, 4, 5, 6],
+            "description": "Public key purpose. 0 - Authentication, 1 - Encryption, 2 - Decryption, 3 - Transfer, 4 - System, 5 - Voting, 6 - Owner",
+            "$comment": "It can't be changed after adding a key"
         },
-        "level": {
+        "securityLevel": {
             "type": "integer",
-            "enum": [
-                0,
-                1,
-                2,
-                3
-            ],
+            "enum": [0, 1, 2, 3],
             "description": "Public key security level. 0 - Master, 1 - Critical, 2 - High, 3 - Medium",
-            "$comment": "It can’t be changed after adding a key"
+            "$comment": "It can't be changed after adding a key"
         },
         "data": {
             "type": "string",
             "contentEncoding": "base64",
             "pattern": "^([A-Za-z0-9+/])+$",
-            "description": "Base64-encoded raw public key",
-            "$comment": "It must be a valid key of the specified type and unique for the identity. It can’t be changed after adding a key"
+            "description": "Base64-encoded raw public key or key hash",
+            "$comment": "It must be a valid key of the specified type and unique for the identity (for key types 0 and 1). It can't be changed after adding a key"
         },
-        "ownershipProof": {
-            "type": "string",
-            "contentEncoding": "base64",
-            "pattern": "^([A-Za-z0-9+/])+$",
-            "description": "Base64-encoded signature of the owner unique identifier",
-            "$comment": "This proves ownership of the key. It can’t be changed after adding a key"
+        "readOnly": {
+            "type": "boolean",
+            "description": "Whether this key is read-only and cannot be disabled",
+            "$comment": "Defaults to false if not specified"
+        },
+        "contractBounds": {
+            "type": "object",
+            "description": "Optional bounds restricting key usage to specific contract scope",
+            "oneOf": [
+                {
+                    "properties": {
+                        "type": { "const": 0 },
+                        "id": {
+                            "type": "string",
+                            "contentEncoding": "base58",
+                            "minLength": 42,
+                            "maxLength": 44
+                        }
+                    },
+                    "required": ["type", "id"],
+                    "$comment": "SingleContract - key can only be used within a specific contract"
+                },
+                {
+                    "properties": {
+                        "type": { "const": 1 },
+                        "id": {
+                            "type": "string",
+                            "contentEncoding": "base58",
+                            "minLength": 42,
+                            "maxLength": 44
+                        },
+                        "documentTypeName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type", "id", "documentTypeName"],
+                    "$comment": "SingleContractDocumentType - key can only be used within a specific contract and document type"
+                }
+            ]
         },
         "disabledAt": {
             "type": "integer",
             "minimum": 0,
-            "description": "Timestamp indicating that the key was disabled at specified time. Although disabled keys cannot be updated, they can be used for signature verification and signing Identity Disable Transitions. Timestamp must not be more than 5 minutes before or 5 minutes after the current platform chain block time"
+            "description": "Timestamp indicating that the key was disabled at specified time. Although disabled keys cannot be updated, they can be used for signature verification. Timestamp must not be more than 5 minutes before or 5 minutes after the current platform chain block time"
         }
     },
     "allOf": [
         {
             "if": {
-                "properties": {
-                    "type": {
-                        "const": 0
-                    }
-                }
+                "properties": { "type": { "const": 0 } }
             },
             "then": {
                 "properties": {
-                    "data": {
-                        "minLength": 44,
-                        "maxLength": 44
-                    },
-                    "ownershipProof": {
-                        "minLength": 87,
-                        "maxLength": 87
-                    }
+                    "data": { "minLength": 44, "maxLength": 44 }
                 }
             }
         },
         {
             "if": {
-                "properties": {
-                    "type": {
-                        "const": 1
-                    }
-                }
+                "properties": { "type": { "const": 1 } }
             },
             "then": {
                 "properties": {
-                    "data": {
-                        "minLength": 64,
-                        "maxLength": 64
-                    },
-                    "ownershipProof": {
-                        "minLength": 128,
-                        "maxLength": 128
-                    }
+                    "data": { "minLength": 64, "maxLength": 64 }
                 }
+            }
+        },
+        {
+            "if": {
+                "properties": { "type": { "enum": [2, 3, 4] } }
+            },
+            "then": {
+                "properties": {
+                    "data": { "minLength": 28, "maxLength": 28 }
+                },
+                "$comment": "20 bytes base64 encoded = 28 characters"
             }
         }
     ],
@@ -108,8 +117,7 @@
         "type",
         "data",
         "purpose",
-        "level",
-        "ownershipProof"
+        "securityLevel"
     ],
     "additionalProperties": false
 }


### PR DESCRIPTION
- Remove isEnabled field (not in implementation)
- Update publicKeys limits (min 5→1, max 4096→15000)
- Add key types 2-4 (ECDSA_HASH160, BIP13_SCRIPT_HASH, EDDSA_25519_HASH160)
- Add key purposes 3-6 (Transfer, System, Voting, Owner)
- Add readOnly and contractBounds properties to Identity Public Key
- Remove ownershipProof property (not in implementation)
- Change Identity Update Transition type from 4 to 5
- Add nonce field to Identity Update Transition
- Mark Identity Disable Transition as reserved for future
- Add Identity Credit Withdrawal Transition (type 6)
- Add Identity Credit Transfer Transition (type 7)
- Update JSON schemas to match implementation

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>